### PR TITLE
get enode from ethereumrust client

### DIFF
--- a/clients/ethereumrust/Dockerfile
+++ b/clients/ethereumrust/Dockerfile
@@ -16,8 +16,8 @@ ADD ethereum_rust.sh /ethereum_rust.sh
 RUN chmod +x /ethereum_rust.sh
 
 # Add the enode URL retriever script.
-# ADD enode.sh /hive-bin/enode.sh
-# RUN chmod +x /hive-bin/enode.sh
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
 
 # Create version.txt
 # RUN /usr/local/bin/ethereum_rust --version | sed -e 's/ethereum_rust \(.*\)/\1/' > /version.txt

--- a/clients/ethereumrust/enode.sh
+++ b/clients/ethereumrust/enode.sh
@@ -1,0 +1,14 @@
+!/bin/bash
+
+# Script to retrieve the enode
+# 
+# This is copied into the validator container by Hive
+# and used to provide a client-specific enode id retriever
+#
+
+# Immediately abort the script on any error encountered
+set -e
+data='{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}'
+TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data $data "localhost:8545" )
+TARGET_ENODE=$(echo ${TARGET_RESPONSE}| jq -r '.result.enode')
+echo "$TARGET_ENODE"

--- a/clients/ethereumrust/enode.sh
+++ b/clients/ethereumrust/enode.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 
 # Script to retrieve the enode
 # 

--- a/clients/ethereumrust/ethereum_rust.sh
+++ b/clients/ethereumrust/ethereum_rust.sh
@@ -92,11 +92,11 @@ fi
 # FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.api=admin,debug,eth,net,web3"
 FLAGS="$FLAGS --http.addr=0.0.0.0  --authrpc.addr=0.0.0.0"
 
-# if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
-#     JWT_SECRET="7365637265747365637265747365637265747365637265747365637265747365"
-#     echo -n $JWT_SECRET > /jwt.secret
-#     FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.jwtsecret=/jwt.secret"
-# fi
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    JWT_SECRET="7365637265747365637265747365637265747365637265747365637265747365"
+    echo -n $JWT_SECRET > /jwt.secret
+    FLAGS="$FLAGS --authrpc.jwtsecret=/jwt.secret"
+fi
 
 # Configure NAT
 # FLAGS="$FLAGS --nat none"


### PR DESCRIPTION
Introduces the enode.sh script to query for the ethereumrust execution client's enode url.

The script is replicated from the configuration of the other supported clients.

I did not notice any difference in the execution of our tests, but this might be necessary for running the devp2p simulations.

Should be merged alongside https://github.com/lambdaclass/ethereum_rust/pull/312