### PR TITLE
Pin `execution-apis` before `totalDifficutly` field removal

### DIFF
--- a/simulators/ethereum/rpc-compat/Dockerfile
+++ b/simulators/ethereum/rpc-compat/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1-alpine as builder
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Clone the tests repo.
-RUN git clone --depth 1 https://github.com/ethereum/execution-apis.git /execution-apis
+RUN git clone --depth 1 --branch v1.0.0-beta.4 https://github.com/ethereum/execution-apis.git /execution-apis
 
 # To run local tests, copy the directory into the same as the simulator and
 # uncomment the line below


### PR DESCRIPTION
While the removal of this field works fine with rpc-compact tests, the engine test suite still relies on it, so we cannot support both the new rpc spec and the engine tests