### PR TITLE
Use forked Geth devp2p testing tool 

### DIFF
--- a/simulators/devp2p/Dockerfile
+++ b/simulators/devp2p/Dockerfile
@@ -3,7 +3,7 @@
 # Build devp2p tool.
 FROM golang:1-alpine as geth-builder
 RUN apk add --update git gcc musl-dev linux-headers
-RUN git clone --b update-devp2p-blocks https://github.com/lambdaclass/go-ethereum.git /go-ethereum
+RUN git clone --branch update-devp2p-blocks https://github.com/lambdaclass/go-ethereum.git /go-ethereum
 WORKDIR /go-ethereum
 RUN go build -v ./cmd/devp2p
 

--- a/simulators/devp2p/Dockerfile
+++ b/simulators/devp2p/Dockerfile
@@ -3,7 +3,7 @@
 # Build devp2p tool.
 FROM golang:1-alpine as geth-builder
 RUN apk add --update git gcc musl-dev linux-headers
-RUN git clone --depth 1 https://github.com/ethereum/go-ethereum.git /go-ethereum
+RUN git clone --b update-devp2p-blocks https://github.com/lambdaclass/go-ethereum.git /go-ethereum
 WORKDIR /go-ethereum
 RUN go build -v ./cmd/devp2p
 


### PR DESCRIPTION
This PR changes the path from which the devp2p testing tool is downloaded. This allows us to use our geth fork with the test checks updated to match the new genesis and chain files added by #9.
Currently, a branch on the geth fork is being downloaded, we should point to a specific commit once it is merged