### PR TITLE
Fix Log Level capped to INFO

### DIFF
--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -111,4 +111,4 @@ fi
 
 # Launch the main client.
 echo "Running ethrex with flags: $FLAGS"
-RUST_LOG=info $ethrex $FLAGS
+$ethrex $FLAGS


### PR DESCRIPTION
Right now we were unable to configure the log level past info, the RUST_LOG variable was overriding the log level filter in the cli.