### PR TITLE
feat(argument): set ethrex flags with env var

### DIFF
--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -109,6 +109,8 @@ fi
 # Configure NAT
 # FLAGS="$FLAGS --nat none"
 
+FLAGS="$FLAGS  $HIVE_ETHREX_FLAGS"
+
 # Launch the main client.
 echo "Running ethrex with flags: $FLAGS"
 $ethrex $FLAGS

--- a/hive.go
+++ b/hive.go
@@ -71,6 +71,8 @@ func main() {
 			"If a very long chain is imported, this timeout may need to be quite large.\n"+
 			"A lower value means that hive won't wait as long in case the node crashes and\n"+
 			"never opens the RPC port.")
+
+		ethrexFlags = flag.String("ethrex.flags", "--evm revm", "Sets arguments for the ethrex client. Mainly used to choose between `revm or levm`")
 	)
 
 	// Add the sim.buildarg flag multiple times to allow multiple build arguments.
@@ -143,6 +145,8 @@ func main() {
 		cancel()
 	}()
 
+	fmt.Printf("ethrexFlag is:%s\n", *ethrexFlags)
+
 	// Run.
 	env := libhive.SimEnv{
 		LogDir:             *testResultsRoot,
@@ -152,6 +156,7 @@ func main() {
 		SimRandomSeed:      *simRandomSeed,
 		SimDurationLimit:   *simTimeLimit,
 		ClientStartTimeout: *clientTimeout,
+		EthrexFlags:        *ethrexFlags,
 	}
 	runner := libhive.NewRunner(inv, builder, cb)
 

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -238,6 +238,9 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		env["HIVE_LOGLEVEL"] = strconv.Itoa(api.env.SimLogLevel)
 	}
 
+	// CUSTOM for ethrex
+	env["HIVE_ETHREX_FLAGS"] = api.env.EthrexFlags
+
 	// Set up the timeout.
 	timeout := api.env.ClientStartTimeout
 	if timeout == 0 {

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -203,6 +203,7 @@ func (r *Runner) run(ctx context.Context, sim string, env SimEnv, hiveInfo HiveI
 			"HIVE_SIMULATOR":    "http://" + server.Addr().String(),
 			"HIVE_PARALLELISM":  strconv.Itoa(env.SimParallelism),
 			"HIVE_LOGLEVEL":     strconv.Itoa(env.SimLogLevel),
+			"HIVE_ETHREX_FLAGS": env.EthrexFlags,
 			"HIVE_TEST_PATTERN": env.SimTestPattern,
 			"HIVE_RANDOM_SEED":  strconv.Itoa(env.SimRandomSeed),
 		},

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -48,6 +48,9 @@ type SimEnv struct {
 	// This configures the amount of time the simulation waits
 	// for the client to open port 8545 after launching the container.
 	ClientStartTimeout time.Duration
+
+	// Ethrex Custom
+	EthrexFlags string
 }
 
 // SimResult summarizes the results of a simulation run.


### PR DESCRIPTION
In order to use levm or revm, we have to set the flag `--evm`. To perform this operation easily, we can pass the env var "through" hive depending on a new CLI argument called `ethrex.flags`. 