### PR TITLE
extend fetch head timeout for sync test

### DIFF
--- a/simulators/ethereum/sync/sync.go
+++ b/simulators/ethereum/sync/sync.go
@@ -194,7 +194,7 @@ func (n *node) checkHead() error {
 
 // head returns the node's chain head.
 func (n *node) head() (*types.Header, error) {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
 	return ethclient.NewClient(n.RPC()).HeaderByNumber(ctx, nil)
 }
 


### PR DESCRIPTION
In ethrex we have been having flaky snap sync tests due to timeout when fetching the latest head.
Extending the timeout window fixes this problem