### PR TITLE
feat: use forked execution-specs-test with a mapper for ethrex errors

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.10-slim
 ## Default fixtures
 ARG fixtures=latest-stable-release
 ENV INPUT=${fixtures}
-ARG branch=main
+ARG branch=add-ethrex-mapper
 ENV BRANCH=${branch}
 
 ## Install dependencies
@@ -14,7 +14,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ## Clone and install EEST
-RUN git clone https://github.com/ethereum/execution-spec-tests.git --branch "$BRANCH" --single-branch --depth 1
+RUN git clone https://github.com/lambdaclass/execution-spec-tests.git --branch "$BRANCH"  --single-branch --depth 1
 WORKDIR execution-spec-tests
 RUN pip install uv && uv sync
 


### PR DESCRIPTION
In order to successfully run the consume-egine hive test suite we need to have a mapper for our errors. This PR changes the download path for the execution specs test runner to our fork of it where we added the mapper. A follow up to this PR would be to send a PR to the execution specs test repo and revert this PR once it is merged. This would aso involve further stabilizing our error handling