### PR TITLE
Chore: returned ethrex to point to your local image 

### DIFF
--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,6 +1,7 @@
 # This is the image we build on a push to main
 # We do have a problem, if we're testing locally it doesn't show changes
 # Removing this from here now, but the upstream version should use the ghcr.io version
+# For now, users needs to build locally ethrex
 # ARG baseimage=ghcr.io/lambdaclass/ethrex 
 ARG baseimage=ethrex # We don
 

--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,7 +1,12 @@
-ARG baseimage=ghcr.io/lambdaclass/ethrex
+# This is the image we build on a push to main
+# We do have a problem, if we're testing locally it doesn't show changes
+# Removing this from here now, but the upstream version should use the ghcr.io version
+# ARG baseimage=ghcr.io/lambdaclass/ethrex 
+ARG baseimage=ethrex # We don
+
 ARG tag=latest
 
-FROM $baseimage:$tag as builder
+FROM $baseimage:$tag AS builder
 
 # Install script tools.
 RUN apt-get update -y


### PR DESCRIPTION
** Motivation **

The image in "ghcr.io/lambdaclass/ethrex" is only updated on main, and it doesn't take into account the locally built image (unless we change the name). Reverting the base image will allow proper local development again.

** Changes **

* Changed the base image of ethrex to "ethrex"
* Added comment explaining the why
