### PR TITLE
update devp2p simulator version

### DIFF
--- a/simulators/devp2p/Dockerfile
+++ b/simulators/devp2p/Dockerfile
@@ -7,7 +7,7 @@ ENV GOPROXY=${GOPROXY}
 RUN apk add --update git gcc musl-dev linux-headers
 RUN git clone https://github.com/ethereum/go-ethereum.git /go-ethereum
 WORKDIR /go-ethereum
-RUN git checkout v1.15.11
+RUN git checkout v1.16.0
 RUN go build -v ./cmd/devp2p
 
 # Build the simulator executable.


### PR DESCRIPTION
**Motivation**
A new [geth version](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.0) has been released, which updates the Hive test suite.

**Description**
Updates the `devp2p` simulator version to include the latest test suite.

> [!CAUTION]
> Do not merge until [#3047](https://github.com/lambdaclass/ethrex/pull/3047) is merged.

