### PR TITLE
Modify genesis.json file to be post merge

### DIFF
--- a/clients/ethrex/mapper.jq
+++ b/clients/ethrex/mapper.jq
@@ -52,7 +52,7 @@ def to_bool:
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
     "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
-    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "mergeNetsplitBlock": (if env.HIVE_MERGE_BLOCK_ID == null then 0 else env.HIVE_MERGE_BLOCK_ID|to_int end),
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED|to_bool,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,


### PR DESCRIPTION
**Motivation**

From ethrex issue [#3628](https://github.com/lambdaclass/268)
the genesis file received by ethrex was a pre-merge version, which isn't supported.

**Description**

The `MergeNetsplitBlock` field now has a default value of 0 set in the `mapper.jq` file, which is supported by ethrex.