### PR TITLE
Update Dockerfile

### DIFF
--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,7 +1,12 @@
 ARG baseimage=ghcr.io/lambdaclass/ethrex
 ARG tag=latest
 
-FROM $baseimage:$tag as builder
+FROM $baseimage:$tag AS builder
+
+FROM ubuntu:24.04
+
+WORKDIR /usr/local/bin
+COPY --from=builder /usr/local/bin/ethrex .
 
 # Install script tools.
 RUN apt-get update -y


### PR DESCRIPTION
Current Dockerfile assumes that the ethrex docker image is based in Debian or related. In the future we may move to another -more minimalist- image base breaking the compatibility.
This PR changes the base image to `ubuntu:24.04` instead of `ethrex`, copying the binary from the latest instead.

Related ethrex PR: https://github.com/lambdaclass/ethrex/pull/3826