### PR TITLE
chore: use unstable tag

### DIFF
--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=ghcr.io/lambdaclass/ethrex
-ARG tag=latest
+ARG tag=unstable
 
 FROM $baseimage:$tag AS builder
 


### PR DESCRIPTION
Use `unstable` tag (referencing to `main` branch) instead of `latest` (latest release).